### PR TITLE
add extra fields to quicklinks for hackathons

### DIFF
--- a/nw-firestore-schema.ts
+++ b/nw-firestore-schema.ts
@@ -38,6 +38,8 @@ interface WebsiteData {
 interface Quicklink {
   label: string;
   href: string;
+  category: string;
+  commonLink: boolean;
 }
 
 interface DayOfEvent {


### PR DESCRIPTION
As per the Figma design 
![image](https://user-images.githubusercontent.com/23178940/91919329-6e5d6080-ec7a-11ea-848e-bf1c44e70079.png)

We should be able to group quick links by category and also be able to distinguish common links from the rest (top bar of buttons)