### PR TITLE
add prizes to schema

### DIFF
--- a/nw-firestore-schema.ts
+++ b/nw-firestore-schema.ts
@@ -48,6 +48,12 @@ interface Quicklink {
   common: boolean;
 }
 
+interface Prize {
+  place: number | boolean; // number if a main prize, false if sponsor prize
+  title: string;
+  content: string; // | delimited 
+}
+
 interface DayOfEvent {
   name: "name";
   type: "notices" | "main" | "workshops" | "minievents";
@@ -84,6 +90,7 @@ interface Hackathon {
   DayOf: DayOfEvent[];
   Announcements: Announcement[];
   Quicklinks: Quicklink[];
+  Prizes: Prize[];
 }
 
 interface Announcement {

--- a/nw-firestore-schema.ts
+++ b/nw-firestore-schema.ts
@@ -52,7 +52,7 @@ interface Prize {
   place: number | boolean; // number if a main prize, false if sponsor prize
   sponsor: string;
   title: string;
-  content: string; // | delimited 
+  content: string[]; 
 }
 
 interface DayOfEvent {

--- a/nw-firestore-schema.ts
+++ b/nw-firestore-schema.ts
@@ -50,6 +50,7 @@ interface Quicklink {
 
 interface Prize {
   place: number | boolean; // number if a main prize, false if sponsor prize
+  sponsor: string;
   title: string;
   content: string; // | delimited 
 }


### PR DESCRIPTION
a prize can be a main prize (1st, 2nd, 3rd) or a sponsor prize (no ordering). If main prize, the "place" will be a number (1 2 3), else it's a sponsor prize and the "place" will be false. 

in the past, we've also had LHD Learn Build Share prizes, in the future we can either incorporate those as sponsor prizes or make a new section for it in the portal/livesite. 