### PR TITLE
New status fields (attending, responded), and added waitlisted as status

### DIFF
--- a/nw-firestore-schema.ts
+++ b/nw-firestore-schema.ts
@@ -103,9 +103,10 @@ interface Application {
     eventsAttended: string[];
   },
   submission: {
-    lastUpdated: timestamp | boolean;
+    lastUpdated: timestamp;
     submitted: boolean;
     status: ApplicationStatus = "applied";
+    rsvp: boolean | false; // false for no-rsvp by default
   },
   team: reference;
 }
@@ -119,10 +120,6 @@ interface Stats {
 interface Hackathon {
   id: "lhd"; //(example)
   Applicants: Application[];
-  Deadlines: {
-    applicationsOpen: timestamp;
-    applicationsClose: timestamp;
-  };
   Hackers: Hacker[];
   WebsiteData: WebsiteData;
   Sponsors: Sponsor[];

--- a/nw-firestore-schema.ts
+++ b/nw-firestore-schema.ts
@@ -70,7 +70,7 @@ type HackerRoles = developer | designer | hardware | product | data | business |
 
 type Engagements = facebook | instagram | twitter | medium | linkedin | event
 
-type ApplicationStatus = applied | accepted | rejected
+type ApplicationStatus = applied | accepted | rejected | waitlisted
 
 interface Application {
   _id: string;  // same as user ID
@@ -105,9 +105,12 @@ interface Application {
   submission: {
     lastUpdated: timestamp;
     submitted: boolean;
-    status: ApplicationStatus = "applied";
-    rsvp: boolean | false; // false for no-rsvp by default
   },
+  status: {
+    applicationStatus: ApplicationStatus = "applied";
+    responded: boolean | false; // using responded and attending to check if they un-RSVPed or if they didn't RSVP at all (no RSVP)
+    attending: boolean | false; // false for no-rsvp by default
+  }
   team: reference;
 }
 // Stats are incomplete, I'd like to collect more data but for now this is all I could think of

--- a/nw-firestore-schema.ts
+++ b/nw-firestore-schema.ts
@@ -81,6 +81,7 @@ interface Application {
     gender: string;
     ethnicity: string[];
     isOfLegalAge: boolean;
+    phoneNumber: number;
     school: string;
     major: string;
     educationLevel: EducationLevels = "bachelors";

--- a/nw-firestore-schema.ts
+++ b/nw-firestore-schema.ts
@@ -70,7 +70,7 @@ type HackerRoles = developer | designer | hardware | product | data | business |
 
 type Engagements = facebook | instagram | twitter | medium | linkedin | event
 
-type ApplicationStatus = applied | accepted | rejected | waitlisted
+type ApplicationStatus = applied | accepted | rejected | waitlisted | inProgress
 
 interface Application {
   _id: string;  // same as user ID

--- a/nw-firestore-schema.ts
+++ b/nw-firestore-schema.ts
@@ -119,6 +119,10 @@ interface Stats {
 interface Hackathon {
   id: "lhd"; //(example)
   Applicants: Application[];
+  Deadlines: {
+    applicationsOpen: timestamp;
+    applicationsClose: timestamp;
+  };
   Hackers: Hacker[];
   WebsiteData: WebsiteData;
   Sponsors: Sponsor[];

--- a/nw-firestore-schema.ts
+++ b/nw-firestore-schema.ts
@@ -81,7 +81,7 @@ interface Application {
     gender: string;
     ethnicity: string[];
     isOfLegalAge: boolean;
-    phoneNumber: number;
+    phoneNumber: string;
     school: string;
     major: string;
     educationLevel: EducationLevels = "bachelors";


### PR DESCRIPTION
- added `responded` and `attending` to determine if hacker has RSVPed, did not RSVP on time (no RSVP), or unRSVPed.
- both fields are false by default but once user responds, `responds = true`

states
- un-RSVPed: `responded && !attending`
- no RSVP or not attending: `!responded && !attending` (they wouldn't click RSVP if not attending)
<img width="827" alt="Screen Shot 2020-11-29 at 8 36 32 PM" src="https://user-images.githubusercontent.com/38872354/100569340-92810b80-3282-11eb-93fc-67e63f681a7c.png">
